### PR TITLE
12.0.5 compat: secret-string guards + toc

### DIFF
--- a/DataStore_Crafts/DataStore_Crafts.lua
+++ b/DataStore_Crafts/DataStore_Crafts.lua
@@ -949,8 +949,9 @@ local function OnChatMsgSkill(self, message)
 	if not message then return end
 
 	-- Check it is the right type of message
-	local skill = message:match(skillUpMsg)
-	if not skill then return end
+	-- In WoW 12.0+, CHAT_MSG_SYSTEM args may be secret strings that cannot be indexed by addons
+	local ok, skill = pcall(string.match, message, skillUpMsg)
+	if not ok or not skill then return end
 	
 	if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
 		local info = C_TradeSkillUI.GetChildProfessionInfo()
@@ -974,8 +975,9 @@ local function OnChatMsgSystem(self, message)
 	if not message then return end
 
 	-- Check it is the right type of message
-	local skillLink = message:match(unlearnMsg)
-	if not skillLink then return end
+	-- In WoW 12.0+, CHAT_MSG_SYSTEM args may be secret strings that cannot be indexed by addons
+	local ok, skillLink = pcall(string.match, message, unlearnMsg)
+	if not ok or not skillLink then return end
 
 	-- Check it is a proper profession
 	local skillName = skillLink:match("%[(.+)%]")

--- a/DataStore_Crafts/DataStore_Crafts.toc
+++ b/DataStore_Crafts/DataStore_Crafts.toc
@@ -1,4 +1,4 @@
-## Interface: 120000
+## Interface: 120000, 120005
 ## Title: DataStore_Crafts
 ## IconTexture: Interface\Icons\garrison_building_storehouse
 

--- a/DataStore_Crafts/DataStore_Crafts_Retail.lua
+++ b/DataStore_Crafts/DataStore_Crafts_Retail.lua
@@ -621,8 +621,9 @@ local function OnChatMsgSystem(self, message)
 	if not message then return end
 
 	-- Check it is the right type of message
-	local skillLink = message:match(unlearnMsg)
-	if not skillLink then return end
+	-- In WoW 12.0+, CHAT_MSG_SYSTEM may be a "secret" string that cannot be indexed by addons
+	local ok, skillLink = pcall(string.match, message, unlearnMsg)
+	if not ok or not skillLink then return end
 
 	-- Check it is a proper profession
 	local skillName = skillLink:match("%[(.+)%]")


### PR DESCRIPTION
## Summary
- Wrap `message:match(...)` calls in `OnChatMsgSkill` / `OnChatMsgSystem` with `pcall` so the addon doesn't error when 12.0+ ships a secret/non-indexable string in CHAT_MSG_SYSTEM / CHAT_MSG_SKILL.
- Declare 12.0.5 support in toc.

## Why
Midnight (12.0) introduced "secret values" that taint execution if you try to index them directly. CHAT_MSG_SYSTEM args can now arrive as such a string, in which case `message:match(...)` taints the addon. Wrapping in `pcall(string.match, ...)` makes the failure recoverable and silent.

## Test plan
- [ ] Trigger a profession skill-up message in 12.0.5 — `OnChatMsgSkill` no longer errors.
- [ ] Unlearn a secondary profession in 12.0.5 — `OnChatMsgSystem` handles the unlearn message without taint.
- [ ] Addon loads without "out of date" warning in 12.0.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)