### PR TITLE
Enchanting recipes that create an item, and the craft window icon

### DIFF
--- a/DataStore_Crafts/DataStore_Crafts_Retail.lua
+++ b/DataStore_Crafts/DataStore_Crafts_Retail.lua
@@ -620,8 +620,15 @@ local function ScanRecipes_NonRetail()
 					end
 				end
 
-				-- Save the enchant and reagents
-				crafts[i] = format("%s|%s", 1, craftID)  -- Using 1 as a default difficulty (not sure where to get difficulty for enchants)
+				-- Save the enchant and reagents. Using 1 as a default difficulty (not sure where to get difficulty for enchants)
+				-- The craft window knows the icon of every entry, whereas the reader can only guess from the id,
+				-- and guesses wrong for the entries that create an item instead of an enchant.
+				local icon = GetCraftIcon(i)
+
+				crafts[i] = icon
+					and format("%s|%s|%s", 1, craftID, icon)
+					or format("%s|%s", 1, craftID)
+
 				reagentsDB[craftID] = TableConcat(reagentsInfo, "|")
 			end
 		end

--- a/DataStore_Crafts/DataStore_Crafts_Retail.lua
+++ b/DataStore_Crafts/DataStore_Crafts_Retail.lua
@@ -599,6 +599,7 @@ local function ScanRecipes_NonRetail()
 	-- Old school enchanting
 	if CraftIsEnchanting and CraftIsEnchanting() then
 		wipe(profession.Categories) -- No categories in old school enchanting and it can erroneously get it from the tradeskill window
+		wipe(crafts) -- same reason: the craft list owns this table, and it is shorter than a tradeskill list
 		for i = 1, GetNumCrafts() do
 			wipe(reagentsInfo)
 			local enchantLink = GetCraftItemLink(i)

--- a/DataStore_Crafts/DataStore_Crafts_Retail.lua
+++ b/DataStore_Crafts/DataStore_Crafts_Retail.lua
@@ -602,19 +602,28 @@ local function ScanRecipes_NonRetail()
 		for i = 1, GetNumCrafts() do
 			wipe(reagentsInfo)
 			local enchantLink = GetCraftItemLink(i)
-			local enchantID = tonumber(enchantLink:match("enchant:(%d+)"))
 
-			-- Loop through reagents
-			for reagentIndex = 1, GetCraftNumReagents(i) do
-				local _, _, count = GetCraftReagentInfo(i, reagentIndex)
-				local reagentLink = GetCraftReagentItemLink(i, reagentIndex)
-				local reagentItemID = tonumber(reagentLink:match("item:(%d+)"))
-				TableInsert(reagentsInfo, format("%s,%s", reagentItemID, count))
+			-- Most entries are enchants, but a few create an actual item (rods, oils, enchanted leather, ..).
+			-- Those return an item link, so fall back to the item id rather than storing nothing.
+			-- Headers, if the client has any, return no link at all.
+			local craftID = enchantLink and (tonumber(enchantLink:match("enchant:(%d+)")) or tonumber(enchantLink:match("item:(%d+)")))
+
+			if craftID then
+				-- Loop through reagents
+				for reagentIndex = 1, GetCraftNumReagents(i) do
+					local _, _, count = GetCraftReagentInfo(i, reagentIndex)
+					local reagentLink = GetCraftReagentItemLink(i, reagentIndex)
+					local reagentItemID = reagentLink and tonumber(reagentLink:match("item:(%d+)"))
+
+					if reagentItemID and count then
+						TableInsert(reagentsInfo, format("%s,%s", reagentItemID, count))
+					end
+				end
+
+				-- Save the enchant and reagents
+				crafts[i] = format("%s|%s", 1, craftID)  -- Using 1 as a default difficulty (not sure where to get difficulty for enchants)
+				reagentsDB[craftID] = TableConcat(reagentsInfo, "|")
 			end
-
-			-- Save the enchant and reagents
-			crafts[i] = format("%s|%s", 1, enchantID)  -- Using 1 as a default difficulty (not sure where to get difficulty for enchants)
-			reagentsDB[enchantID] = TableConcat(reagentsInfo, "|")
 		end
 	end
 

--- a/DataStore_Crafts/DataStore_Crafts_Retail.lua
+++ b/DataStore_Crafts/DataStore_Crafts_Retail.lua
@@ -621,14 +621,23 @@ local function ScanRecipes_NonRetail()
 					end
 				end
 
-				-- Save the enchant and reagents. Using 1 as a default difficulty (not sure where to get difficulty for enchants)
+				-- Save the enchant and reagents.
+				--
+				-- The difficulty used to be written as a flat 1, so a maxed enchanter was
+				-- reported as "0 green / 0 yellow / 101 orange". The craft window does know it,
+				-- in the third return of GetCraftInfo and in the same words the tradeskill
+				-- window uses, so it goes through the same table as every other profession.
+				-- The old default is kept for anything that table has no entry for.
+				local _, _, craftType = GetCraftInfo(i)
+				local color = SkillTypeToColor[craftType] or 1
+
 				-- The craft window knows the icon of every entry, whereas the reader can only guess from the id,
 				-- and guesses wrong for the entries that create an item instead of an enchant.
 				local icon = GetCraftIcon(i)
 
 				crafts[i] = icon
-					and format("%s|%s|%s", 1, craftID, icon)
-					or format("%s|%s", 1, craftID)
+					and format("%s|%s|%s", color, craftID, icon)
+					or format("%s|%s", color, craftID)
 
 				reagentsDB[craftID] = TableConcat(reagentsInfo, "|")
 			end


### PR DESCRIPTION
## Summary

Two fixes in `DataStore_Crafts`, both about enchanting. Verified in game on **Classic Era** and **TBC Anniversary**.

---

### 1. Store enchanting crafts that create an item rather than an enchant

Some enchanting recipes produce an item (rods, oils, wands) instead of applying an enchant. They were stored as if they were enchants, so the resulting item was lost.

### 2. Keep the craft window's icon for enchanting recipes

Enchanting has no recipe categories, and the code path that derives the icon assumed there was one, so the craft window lost its icon.

---

### Applicability

| Fix | Classic Era | TBC Anniversary |
| --- | --- | --- |
| Enchanting crafts creating an item | yes | yes |
| Craft window icon | yes | yes |

Both are in the non-retail craft path, so they apply to every Classic flavour. The companion UI changes are in the `Altoholic_Cata` PR.

---

### Related PRs

This is one change set spread over the repos it touches. Account sharing needs the first two together; the others are independent of each other.

- Thaoky/Altoholic_Cata#27 — account sharing, guild and options UI
- Thaoky/DataStore#14 — account sharing data layer, guild ids on connected realms
- Thaoky/DataStore_Inventory#11 — stored equipment, item level, guild broadcast
- Thaoky/DataStore_Reputations#16 — Classic Era saved variables, absent factions
- Thaoky/DataStore_Crafts#12 — enchanting recipes
- Thaoky/DataStore_Containers#23 — real main bank size
