### PR TITLE
Recipes dropped by the scan, and the non-retail recipe counts

### DIFF
--- a/DataStore_Crafts/DataStore_Crafts_Retail.lua
+++ b/DataStore_Crafts/DataStore_Crafts_Retail.lua
@@ -532,14 +532,15 @@ local function ScanRecipes_NonRetail()
 		end
 		
 		-- Get recipeID
-		
+
+		recipeID = nil		-- reset it, or an entry without a valid link would inherit the previous entry's id
 		recipeLink = GetTradeSkillRecipeLink(i) -- add recipe link here to get recipeID
 		if not recipeLink then
 			recipeLink = GetCraftRecipeLink(i)
 		end
 		if recipeLink then
-			local found, _, enchantString = string.find(recipeLink, "^|%x+|H(.+)|h%[.+%]")
-			recipeID = tonumber(enchantString:match("enchant:(%d+)"))
+			-- an unexpected link format must not throw, or the rest of the list would not be scanned at all
+			recipeID = tonumber(recipeLink:match("|Henchant:(%d+)"))
 			if recipeID then
 				reagentsDB[recipeID] = TableConcat(reagentsInfo, "|")
 			end

--- a/DataStore_Crafts/DataStore_Crafts_Retail.lua
+++ b/DataStore_Crafts/DataStore_Crafts_Retail.lua
@@ -919,15 +919,26 @@ end
 
 local function _GetNumRecipesByColor(profession)
 	-- counts the number of orange, yellow, green and grey recipes.
-	local counts = { [0] = 0, [1] = 0, [2] = 0, [3] = 0 }
-	
-	_IterateRecipes(profession, 0, 0, function(recipeData) 
+	local counts = { [0] = 0, [1] = 0, [2] = 0, [3] = 0, [4] = 0 }
+
+	-- Non-retail hands the color index straight to the callback, and does not call back for headers.
+	if not isRetail then
+		_IterateRecipes(profession, 0, 0, function(color)
+			if color then
+				counts[color] = (counts[color] or 0) + 1
+			end
+		end)
+
+		return counts[1], counts[2], counts[3], counts[4]		-- orange, yellow, green, grey
+	end
+
+	_IterateRecipes(profession, 0, 0, function(recipeData)
 		if recipeData then
 			local color = _GetRecipeInfo(recipeData)
-			counts[color] = counts[color] + 1
+			counts[color] = (counts[color] or 0) + 1
 		end
 	end)
-	
+
 	return counts[3], counts[2], counts[1], counts[0]		-- orange, yellow, green, grey
 end
 

--- a/DataStore_Crafts/DataStore_Crafts_Retail.lua
+++ b/DataStore_Crafts/DataStore_Crafts_Retail.lua
@@ -321,12 +321,16 @@ local function ScanProfessionLinks()
 	AddonFactory:Broadcast("DATASTORE_PROFESSION_LINKS_UPDATED")
 end
 
+local SKILL_GREY = 4
+
 local SkillTypeToColor = {
 	["header"] = 0,
+	["subheader"] = 0,		-- lists are grouped by header, and sometimes by subheader
 	["optimal"] = 1,		-- orange
 	["medium"] = 2,		-- yellow
 	["easy"] = 3,			-- green
 	["trivial"] = 4,		-- grey
+	["nodifficulty"] = 4,	-- white, ie: recipes that never grant a skill up, mostly the epic ones. Grey is the closest match.
 }
 
 local function ScanCooldowns()
@@ -570,30 +574,31 @@ local function ScanRecipes_NonRetail()
 			
 		end
 		-- Scan recipe
-		local color = SkillTypeToColor[skillType]
+		-- An unknown skill type must still be stored: dropping it not only loses the recipe,
+		-- it leaves a hole in the crafts array, and the readers stop at the first hole.
+		local color = SkillTypeToColor[skillType] or SKILL_GREY
 		local craftInfo
 
-		if color then
-			if skillType == "header" then
-				craftInfo = skillName or ""
-				TableInsert(profession.Categories, skillName)
-			else
-				-- cooldowns, if any
-				local cooldown = GetTradeSkillCooldown(i)
-				if cooldown then
-				-- ex: "Hexweave Cloth|86220|1533539676" expire at "now + cooldown"
-					TableInsert(profession.Cooldowns, format("%s|%d|%d", skillName, cooldown, cooldown + time()))
-				end
-
-				-- if there is a valid recipeID, save it
-				if recipeLink then
-					craftInfo = (recipeLink and recipeID) and recipeID or ""
-				else
-					craftInfo = (link and itemID) and itemID or ""
-				end
+		if color == 0 then
+			craftInfo = skillName or ""
+			TableInsert(profession.Categories, skillName)
+		else
+			-- cooldowns, if any
+			local cooldown = GetTradeSkillCooldown(i)
+			if cooldown then
+			-- ex: "Hexweave Cloth|86220|1533539676" expire at "now + cooldown"
+				TableInsert(profession.Cooldowns, format("%s|%d|%d", skillName, cooldown, cooldown + time()))
 			end
-			crafts[i] = format("%s|%s", color, craftInfo)
+
+			-- if there is a valid recipeID, save it
+			if recipeLink then
+				craftInfo = (recipeLink and recipeID) and recipeID or ""
+			else
+				craftInfo = (link and itemID) and itemID or ""
+			end
 		end
+
+		crafts[i] = format("%s|%s", color, craftInfo)
 	end
 
 	-- Old school enchanting


### PR DESCRIPTION
Three defects in `ScanRecipes_NonRetail()` and its reader, found while chasing a report of learnt recipes missing from Altoholic. Independent commits, take or leave them separately.

### Recipes whose difficulty the client does not color are dropped

`SkillTypeToColor` knows `header`, `optimal`, `medium`, `easy` and `trivial`, and an entry is stored only if the lookup succeeds. `GetTradeSkillInfo()` also returns `nodifficulty` — Blizzard's own `TradeSkillTypeColor` lists it, drawn in white, for recipes that can never grant a skill up, in practice mostly epic patterns — and `subheader`, which the same function already expects when it tests the first line of the list.

Dropping an entry also leaves a hole in `Crafts`, which is indexed by list position, and both readers walk it with `for i = 1, #crafts`. The length of a table with a hole is any border Lua cares to return, so one white recipe can truncate the rest of the list too. The `-- Somehow the scan can set an item to nil` guard in `_IterateRecipes()` is that symptom.

Unknown types now fall back to grey instead of being dropped, so a type added by a future patch costs a wrong color rather than a missing recipe.

**Not reproduced.** It matches a report of epic recipes missing from tailoring and enchanting on Mists that I could not reproduce myself, and it is a defect on its own terms either way.

### A recipe could inherit the previous recipe's id

`recipeID` is declared above the loop and only assigned inside `if recipeLink then`, so an entry whose link carries no enchant id kept the previous entry's — used both to key `resultItemsDB` and to store the recipe itself.

The extraction was also unchecked: `string.find(...)` then `enchantString:match(...)` on the next line throws if the link does not match the pattern. Since `Crafts` is wiped before the loop, an error part way through leaves the profession holding only what had been read so far. Matching the id directly against the link cannot throw and returns the same value for the normal form.

### Orange and green recipe counts are swapped on non-retail

`_GetNumRecipesByColor()` is written for retail and registered for every flavour, but the two `_IterateRecipes()` implementations do not pass the same thing to their callback: retail passes bit packed data, non-retail passes the color index. The index went through `_GetRecipeInfo()`, which read it as packed data, then the counters were read back in retail's order.

A leatherworker with 9 orange, 6 yellow, 4 green and 131 grey recipes was announced as 4 orange and 9 green in the Summary tooltip. The total was right, which is presumably why it went unnoticed. The split restored here is the one `DataStore_Crafts.lua` still carries as `_GetNumRecipesByColor_Retail` / `_NonRetail`; the merged file kept the retail one only.

Verified in game on Classic Era: 150 recipes, 4 green, 6 yellow, 9 orange.

---

Tested on Classic Era and TBC Anniversary. The scan change is the only one not backed by a reproduction.